### PR TITLE
chore(support): react 17 version and node 14 above supports

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-carbonui",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "A carbon copy UI to show the web page based on the traditional view",
   "scripts": {
     "rollup": "rollup -c",
@@ -56,13 +56,16 @@
     "typescript": "^4.9.5"
   },
   "peerDependencies": {
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": "^17.0.0 || ^18.2.0",
+    "react-dom": "^17.0.0 || ^18.2.0"
   },
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "files": [
     "dist"
   ],
-  "types": "dist/index.d.ts"
+  "types": "dist/index.d.ts",
+  "engines": {
+    "node": ">=14"
+  }
 }


### PR DESCRIPTION
Adding support to react 17 version

Now no need to add `--legacy-peer-deps` while installing `react-carbonui` package
